### PR TITLE
Separated Product Hub options config for mainnet and testnet

### DIFF
--- a/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
+++ b/features/productHub/controls/ProductHubNaturalLanguageSelectorController.tsx
@@ -1,9 +1,14 @@
+import { isTestnetNetworkId, NetworkIds, useCustomNetworkParameter } from 'blockchain/networks'
 import { HeaderSelector, HeaderSelectorOption } from 'components/HeaderSelector'
-import { ALL_ASSETS, productHubOptionsMap } from 'features/productHub/meta'
+import {
+  ALL_ASSETS,
+  productHubOptionsMap,
+  productHubTestnetOptionsMap,
+} from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import React, { FC, useEffect, useRef, useState } from 'react'
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Heading } from 'theme-ui'
 
 interface ProductHubNaturalLanguageSelectorControllerProps {
@@ -18,13 +23,20 @@ export const ProductHubNaturalLanguageSelectorController: FC<
   ProductHubNaturalLanguageSelectorControllerProps
 > = ({ gradient, product, token, url, onChange }) => {
   const { t } = useTranslation()
+  const [networkParameter] = useCustomNetworkParameter()
+
+  const productHubOptions = useMemo(() => {
+    return isTestnetNetworkId(networkParameter?.id ?? NetworkIds.MAINNET)
+      ? productHubTestnetOptionsMap
+      : productHubOptionsMap
+  }, [networkParameter?.id])
 
   const [overwriteOption, setOverwriteOption] = useState<HeaderSelectorOption>()
   const [selectedProduct, setSelectedProduct] = useState<ProductHubProductType>(
-    productHubOptionsMap[product].product.value as ProductHubProductType,
+    productHubOptions[product].product.value as ProductHubProductType,
   )
   const [selectedToken, setSelectedToken] = useState<string>(
-    (token ? productHubOptionsMap[product].tokens[token] : productHubOptionsMap[product].tokens.all)
+    (token ? productHubOptions[product].tokens[token] : productHubOptions[product].tokens.all)
       .value,
   )
   const ref = useRef<HTMLDivElement>(null)
@@ -39,21 +51,21 @@ export const ProductHubNaturalLanguageSelectorController: FC<
       <Heading as="h1" variant="header2" sx={{ position: 'relative', zIndex: 2 }}>
         {t('product-hub.header.i-want-to')}
         <HeaderSelector
-          defaultOption={productHubOptionsMap[product].product}
+          defaultOption={productHubOptions[product].product}
           gradient={gradient}
-          options={Object.values(productHubOptionsMap).map((option) => option.product)}
+          options={Object.values(productHubOptions).map((option) => option.product)}
           parentRef={ref}
           withHeaders={true}
           onChange={(selected) => {
             const typedValue = selected.value as ProductHubProductType
             const tokenInUrl = selectedToken !== ALL_ASSETS ? selectedToken : undefined
             const isSwitchingToAllAssets = !Object.values(
-              productHubOptionsMap[typedValue].tokens,
+              productHubOptions[typedValue].tokens,
             ).some((option) => option.value === selectedToken)
 
             setSelectedProduct(typedValue)
             setOverwriteOption(
-              isSwitchingToAllAssets ? productHubOptionsMap[typedValue].tokens.all : undefined,
+              isSwitchingToAllAssets ? productHubOptions[typedValue].tokens.all : undefined,
             )
             if (url)
               void push(
@@ -66,12 +78,10 @@ export const ProductHubNaturalLanguageSelectorController: FC<
         {t(`product-hub.header.conjunction.${selectedProduct}`)}
         <HeaderSelector
           defaultOption={
-            token
-              ? productHubOptionsMap[product].tokens[token]
-              : productHubOptionsMap[product].tokens.all
+            token ? productHubOptions[product].tokens[token] : productHubOptions[product].tokens.all
           }
           gradient={gradient}
-          options={Object.values(productHubOptionsMap[selectedProduct].tokens)}
+          options={Object.values(productHubOptions[selectedProduct].tokens)}
           overwriteOption={overwriteOption}
           parentRef={ref}
           valueAsLabel={true}

--- a/features/productHub/meta.ts
+++ b/features/productHub/meta.ts
@@ -90,6 +90,39 @@ export const productHubOptionsMap: {
       all: productHubTokenOptions.all,
       ETH: productHubTokenOptions.ETH,
       WBTC: productHubTokenOptions.WBTC,
+    },
+  },
+  multiply: {
+    product: productHubProductOptions.multiply,
+    tokens: {
+      all: productHubTokenOptions.all,
+      ETH: productHubTokenOptions.ETH,
+      WBTC: productHubTokenOptions.WBTC,
+      USDC: productHubTokenOptions.USDC,
+    },
+  },
+  earn: {
+    product: productHubProductOptions.earn,
+    tokens: {
+      all: productHubTokenOptions.all,
+      ETH: productHubTokenOptions.ETH,
+      DAI: productHubTokenOptions.DAI,
+    },
+  },
+}
+
+export const productHubTestnetOptionsMap: {
+  [key in ProductHubProductType]: {
+    product: HeaderSelectorOption
+    tokens: { [key: string]: HeaderSelectorOption }
+  }
+} = {
+  borrow: {
+    product: productHubProductOptions.borrow,
+    tokens: {
+      all: productHubTokenOptions.all,
+      ETH: productHubTokenOptions.ETH,
+      WBTC: productHubTokenOptions.WBTC,
       USDC: productHubTokenOptions.USDC,
     },
   },

--- a/features/productHub/views/ProductHubRouteHandler.tsx
+++ b/features/productHub/views/ProductHubRouteHandler.tsx
@@ -3,7 +3,11 @@ import { WithConnection } from 'components/connectWallet'
 import { WithFeatureToggleRedirect } from 'components/FeatureToggleRedirect'
 import { AppLayout } from 'components/Layouts'
 import { getProductHubStaticProps } from 'features/productHub/helpers/getProductHubStaticProps'
-import { ALL_ASSETS, productHubOptionsMap } from 'features/productHub/meta'
+import {
+  ALL_ASSETS,
+  productHubOptionsMap,
+  productHubTestnetOptionsMap,
+} from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
 import { ProductHubView } from 'features/productHub/views'
 import { WithChildren } from 'helpers/types'
@@ -37,10 +41,10 @@ export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
     locales?.flatMap((locale) =>
       Object.values(ProductHubProductType)
         .flatMap((product) =>
-          Object.values(productHubOptionsMap[product].tokens).map((token) => [
-            product,
-            ...(token.value !== ALL_ASSETS ? [token.value] : []),
-          ]),
+          Object.values({
+            ...productHubOptionsMap[product].tokens,
+            ...productHubTestnetOptionsMap[product].tokens,
+          }).map((token) => [product, ...(token.value !== ALL_ASSETS ? [token.value] : [])]),
         )
         .map((slug) => ({ params: { slug }, locale })),
     ) || []

--- a/pages/[networkOrProduct]/[token].tsx
+++ b/pages/[networkOrProduct]/[token].tsx
@@ -1,4 +1,8 @@
-import { ALL_ASSETS, productHubOptionsMap } from 'features/productHub/meta'
+import {
+  ALL_ASSETS,
+  productHubOptionsMap,
+  productHubTestnetOptionsMap,
+} from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
 import ProductHubRouteHandler from 'features/productHub/views/ProductHubRouteHandler'
 import { GetStaticPaths } from 'next'
@@ -11,7 +15,10 @@ export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
     locales?.flatMap((locale) =>
       Object.values(ProductHubProductType)
         .flatMap((product) =>
-          Object.values(productHubOptionsMap[product].tokens).map((token) =>
+          Object.values({
+            ...productHubOptionsMap[product].tokens,
+            ...productHubTestnetOptionsMap[product].tokens,
+          }).map((token) =>
             token.value !== ALL_ASSETS
               ? [product, ...(token.value !== ALL_ASSETS ? [token.value] : [])]
               : undefined,

--- a/pages/ajna/[...slug]/index.tsx
+++ b/pages/ajna/[...slug]/index.tsx
@@ -5,7 +5,11 @@ import { AjnaProductHubController } from 'features/ajna/common/controls/AjnaProd
 import { AjnaLayout, ajnaPageSeoTags } from 'features/ajna/common/layout'
 import { AjnaProductController } from 'features/ajna/positions/common/controls/AjnaProductController'
 import { getProductHubStaticProps } from 'features/productHub/helpers/getProductHubStaticProps'
-import { ALL_ASSETS, productHubOptionsMap } from 'features/productHub/meta'
+import {
+  ALL_ASSETS,
+  productHubOptionsMap,
+  productHubTestnetOptionsMap,
+} from 'features/productHub/meta'
 import { ProductHubProductType } from 'features/productHub/types'
 import { uniq, upperFirst } from 'lodash'
 import { GetStaticPaths, GetStaticProps } from 'next'
@@ -54,10 +58,10 @@ export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
     locales?.flatMap((locale) =>
       Object.values(ProductHubProductType)
         .flatMap((product) => [
-          ...Object.values(productHubOptionsMap[product].tokens).map((token) => [
-            product,
-            ...(token.value !== ALL_ASSETS ? [token.value] : []),
-          ]),
+          ...Object.values({
+            ...productHubOptionsMap[product].tokens,
+            ...productHubTestnetOptionsMap[product].tokens,
+          }).map((token) => [product, ...(token.value !== ALL_ASSETS ? [token.value] : [])]),
           ...uniq(
             Object.keys({
               ...getNetworkContracts(NetworkIds.MAINNET).ajnaPoolPairs,


### PR DESCRIPTION
# Separated Product Hub options config for mainnet and testnet
  
## Changes 👷‍♀️

- Created separated configs for options in natural language selector for mainnet and testnet.
  
## How to test 🧪

Self explanatory.
