### PR TITLE
[Oasis Create] Add links to positions for aave v2/v3 and maker

### DIFF
--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -1,7 +1,44 @@
+import { strategies as aaveStrategyList } from 'features/aave'
 import { ProductHubItem, ProductHubProductType } from 'features/productHub/types'
+import { getFeatureToggle } from 'helpers/useFeatureToggle'
 import { LendingProtocol } from 'lendingProtocols'
 
-export function getActionUrl({ earnStrategy, label, product, protocol }: ProductHubItem): string {
+const getAaveStrategyUrl = ({
+  aaveVersion,
+  product,
+  protocol,
+  primaryToken,
+  secondaryToken,
+  network,
+}: Partial<ProductHubItem> & { aaveVersion: 'v2' | 'v3' }) => {
+  const search = aaveStrategyList.find((strategy) => {
+    return (
+      product
+        ?.map((prod) => prod.toLocaleLowerCase())
+        ?.includes(strategy.type.toLocaleLowerCase() as ProductHubProductType) &&
+      strategy.protocol === protocol &&
+      strategy.tokens.collateral.toLocaleLowerCase() === primaryToken?.toLocaleLowerCase() &&
+      strategy.tokens.debt.toLocaleLowerCase() === secondaryToken?.toLocaleLowerCase() &&
+      strategy.network === network
+    )
+  })
+  if (!search?.urlSlug || (search?.featureToggle && !getFeatureToggle(search?.featureToggle))) {
+    return '/'
+  }
+  return `/${network}/aave/${aaveVersion}/${product!.join('') /* should be only one for aave */}/${
+    search!.urlSlug
+  }`
+}
+
+export function getActionUrl({
+  earnStrategy,
+  label,
+  product,
+  protocol,
+  primaryToken,
+  secondaryToken,
+  network,
+}: ProductHubItem): string {
   switch (protocol) {
     case LendingProtocol.Ajna:
       const productInUrl = earnStrategy?.includes('Yield Loop')
@@ -10,8 +47,27 @@ export function getActionUrl({ earnStrategy, label, product, protocol }: Product
 
       return `/ajna/${productInUrl}/${label.replace('/', '-')}`
     case LendingProtocol.AaveV2:
+      return getAaveStrategyUrl({
+        aaveVersion: 'v2',
+        product,
+        protocol,
+        primaryToken,
+        secondaryToken,
+        network,
+      })
     case LendingProtocol.AaveV3:
+      return getAaveStrategyUrl({
+        aaveVersion: 'v3',
+        product,
+        protocol,
+        primaryToken,
+        secondaryToken,
+        network,
+      })
     case LendingProtocol.Maker:
-      return '/'
+      if (label === 'DSR') {
+        return '/earn/dsr/'
+      }
+      return `/vaults/open/${label.split('/').length ? label.split('/')[0] : label}`
   }
 }

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -178,7 +178,7 @@ export function parseRows(
         <AssetsTableDataCellAction
           cta={urlDisabled ? 'Coming soon' : upperFirst(product)}
           link={url}
-          disabled={url === '/'}
+          disabled={urlDisabled}
         />
       ),
     }

--- a/features/productHub/helpers/parseRows.tsx
+++ b/features/productHub/helpers/parseRows.tsx
@@ -160,6 +160,9 @@ export function parseRows(
 
     if (reverseTokens) icons.reverse()
 
+    const url = getActionUrl({ ...row, product: [product] })
+    const urlDisabled = url === '/'
+
     return {
       [product === ProductHubProductType.Earn ? 'depositToken' : 'collateralDebt']: (
         <AssetsTableDataCellAsset asset={asset} icons={icons} />
@@ -173,8 +176,9 @@ export function parseRows(
       ),
       action: (
         <AssetsTableDataCellAction
-          cta={upperFirst(product)}
-          link={getActionUrl({ ...row, product: [product] })}
+          cta={urlDisabled ? 'Coming soon' : upperFirst(product)}
+          link={url}
+          disabled={url === '/'}
         />
       ),
     }

--- a/pages/earn/dsr/index.tsx
+++ b/pages/earn/dsr/index.tsx
@@ -5,6 +5,7 @@ import { useAccount } from 'helpers/useAccount'
 import { GetServerSidePropsContext } from 'next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useRouter } from 'next/router'
+import React from 'react'
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   return {

--- a/pages/earn/dsr/index.tsx
+++ b/pages/earn/dsr/index.tsx
@@ -1,3 +1,5 @@
+import { ethereumMainnetHexId } from 'blockchain/networks'
+import { WithWalletConnection } from 'components/connectWallet'
 import { AppLayout } from 'components/Layouts'
 import { useAccount } from 'helpers/useAccount'
 import { GetServerSidePropsContext } from 'next'
@@ -20,7 +22,7 @@ function DsrProxyPage({ walletAddress }: { walletAddress: string }) {
     void replace(`/earn/dsr/${walletContextAddress}`)
   }
 
-  return null
+  return <WithWalletConnection chainId={ethereumMainnetHexId}>{null}</WithWalletConnection>
 }
 
 DsrProxyPage.layout = AppLayout

--- a/pages/earn/dsr/index.tsx
+++ b/pages/earn/dsr/index.tsx
@@ -1,0 +1,28 @@
+import { AppLayout } from 'components/Layouts'
+import { useAccount } from 'helpers/useAccount'
+import { GetServerSidePropsContext } from 'next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useRouter } from 'next/router'
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...(await serverSideTranslations(ctx.locale!, ['common'])),
+      walletAddress: ctx.query.wallet || null,
+    },
+  }
+}
+
+function DsrProxyPage({ walletAddress }: { walletAddress: string }) {
+  const { walletAddress: walletContextAddress } = useAccount()
+  const { replace } = useRouter()
+  if (!walletAddress && walletContextAddress) {
+    void replace(`/earn/dsr/${walletContextAddress}`)
+  }
+
+  return null
+}
+
+DsrProxyPage.layout = AppLayout
+
+export default DsrProxyPage


### PR DESCRIPTION
# [[Oasis Create] Add links to positions for aave v2/v3 and maker](https://app.shortcut.com/oazo-apps/story/9847/oasis-create-data-add-links-to-positions-for-aave-v2-v3-and-maker)

## Changes 👷‍♀️
- Aave V2, Aave V3 products now links to proper opening page
- - those utilize set feature flags, so some are disabled ("Coming soon")
- Maker products links to proper opening page
- DSR links to `/earn/dsr`, where the connected user is detected and redirected properly

## How to test 🧪
- check Oasis Create links for the above protocols
