### PR TITLE
Update navigation

### DIFF
--- a/components/BlockNativeAvatar.tsx
+++ b/components/BlockNativeAvatar.tsx
@@ -4,15 +4,14 @@ import React from 'react'
 import { Box, Image, SxStyleProp } from 'theme-ui'
 
 type BlockNativeAvatarProps = {
-  small?: boolean
   sx?: SxStyleProp
 }
 
-export function BlockNativeAvatar({ small = false, sx }: BlockNativeAvatarProps) {
+export function BlockNativeAvatar({ sx }: BlockNativeAvatarProps) {
   const [{ wallet }] = useConnectWallet()
   const sizes = {
-    box: small ? '32px' : '42px',
-    icon: small ? '18px' : '24px',
+    box: '32px',
+    icon: '20px',
   }
   return (
     <Box

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -32,6 +32,7 @@ const FOOTER_SECTIONS = [
   {
     titleKey: 'nav.resources',
     links: [
+      { labelKey: 'nav.discover', url: INTERNAL_LINKS.discover, target: '_self' },
       { labelKey: 'nav.blog', url: EXTERNAL_LINKS.BLOG.MAIN, target: '_self' },
       // add link
       { labelKey: 'nav.knowledge-centre', url: EXTERNAL_LINKS.KB.HELP, target: '_blank' },

--- a/components/navigation/NavigationMenuLink.tsx
+++ b/components/navigation/NavigationMenuLink.tsx
@@ -1,17 +1,34 @@
 import { AppLink } from 'components/Links'
 import { useRouter } from 'next/router'
 import React, { ReactNode } from 'react'
-import { Box } from 'theme-ui'
+import { Box, Text } from 'theme-ui'
 
-export interface NavigationMenuPanelLinkType {
-  label: ReactNode
+interface NavigationMenuPanelLinkWithUrl {
   link: string
+  onClick?: never
+}
+
+interface NavigationMenuPanelLinkWithAction {
+  link?: never
+  onClick: () => void
+}
+
+export type NavigationMenuPanelLinkType = (
+  | NavigationMenuPanelLinkWithUrl
+  | NavigationMenuPanelLinkWithAction
+) & {
+  label: ReactNode
 }
 type NavigationMenuPanelLinkProps = NavigationMenuPanelLinkType & {
   onMouseEnter(): void
 }
 
-export function NavigationMenuLink({ label, link, onMouseEnter }: NavigationMenuPanelLinkProps) {
+export function NavigationMenuLink({
+  label,
+  link,
+  onClick,
+  onMouseEnter,
+}: NavigationMenuPanelLinkProps) {
   const { asPath } = useRouter()
 
   return (
@@ -23,17 +40,35 @@ export function NavigationMenuLink({ label, link, onMouseEnter }: NavigationMenu
       }}
       onMouseEnter={onMouseEnter}
     >
-      <AppLink
-        href={link}
-        sx={{
-          color: asPath.includes(link) ? 'primary100' : 'neutral80',
-          whiteSpace: 'nowrap',
-          transition: 'color 200ms',
-          '&:hover': { color: 'primary100' },
-        }}
-      >
-        {label}
-      </AppLink>
+      {link && (
+        <AppLink
+          href={link}
+          sx={{
+            color: asPath.includes(link) ? 'primary100' : 'neutral80',
+            whiteSpace: 'nowrap',
+            transition: 'color 200ms',
+            '&:hover': { color: 'primary100' },
+          }}
+        >
+          {label}
+        </AppLink>
+      )}
+      {onClick && (
+        <Text
+          as="span"
+          variant="boldParagraph3"
+          onClick={onClick}
+          sx={{
+            color: 'neutral80',
+            whiteSpace: 'nowrap',
+            transition: 'color 200ms',
+            cursor: 'pointer',
+            '&:hover': { color: 'primary100' },
+          }}
+        >
+          {label}
+        </Text>
+      )}
     </Box>
   )
 }

--- a/components/navigation/NavigationMenuOrb.tsx
+++ b/components/navigation/NavigationMenuOrb.tsx
@@ -32,7 +32,7 @@ export function NavigationOrb({
   children,
   customIcon,
   icon,
-  iconSize = 16,
+  iconSize = 14,
   isDisabled,
   link,
   onClick,
@@ -64,7 +64,8 @@ export function NavigationOrb({
           sx={{
             position: 'relative',
             width: 'auto',
-            minWidth: '50px',
+            minWidth: '40px',
+            height: '40px',
             p: 1,
             color: isOpen ? 'primary100' : 'neutral80',
             boxShadow: 'buttonMenu',
@@ -88,6 +89,8 @@ export function NavigationOrb({
           href={link}
           sx={{
             position: 'relative',
+            width: '40px',
+            height: '40px',
             color: isOpen ? 'primary100' : 'neutral80',
             boxShadow: 'buttonMenu',
             transition: 'background-color 200ms',

--- a/components/navigation/NavigationMobileMenuLink.tsx
+++ b/components/navigation/NavigationMobileMenuLink.tsx
@@ -8,15 +8,19 @@ type NavigationMobileMenuLinkProps = NavigationMenuPanelLinkType
 
 export function NavigationMobileMenuLink({ label, link }: NavigationMobileMenuLinkProps) {
   return (
-    <Box key={`link-${label}`} as="li">
-      <AppLink
-        href={link}
-        sx={{
-          ...mobileLinkSx,
-        }}
-      >
-        {label}
-      </AppLink>
-    </Box>
+    <>
+      {link && (
+        <Box key={`link-${label}`} as="li">
+          <AppLink
+            href={link}
+            sx={{
+              ...mobileLinkSx,
+            }}
+          >
+            {label}
+          </AppLink>
+        </Box>
+      )}
+    </>
   )
 }

--- a/components/navigation/NavigationNetworkSwitcherIcon.tsx
+++ b/components/navigation/NavigationNetworkSwitcherIcon.tsx
@@ -9,6 +9,6 @@ export function NavigationNetworkSwitcherIcon(_isOpen: boolean) {
   return isWalletConnecting || !icon ? (
     <AppSpinner />
   ) : (
-    <Image src={icon} sx={{ width: '42px', height: '42px' }} />
+    <Image src={icon} sx={{ width: '32px', height: '32px' }} />
   )
 }

--- a/components/navigation/content/MyPositionsOrb.tsx
+++ b/components/navigation/content/MyPositionsOrb.tsx
@@ -8,7 +8,7 @@ export function MyPositionsOrb() {
   return (
     <NavigationOrb
       icon="home"
-      iconSize={20}
+      iconSize={16}
       link={`/owner/${walletAddress}`}
       {...(!!amountOfPositions && { beacon: amountOfPositions })}
     />

--- a/components/navigation/content/NotificationsOrb.tsx
+++ b/components/navigation/content/NotificationsOrb.tsx
@@ -12,7 +12,6 @@ export function NotificationsOrb() {
   return (
     <NavigationOrb
       icon="bell"
-      iconSize={16}
       isDisabled={!notificationsState}
       width={380}
       {...(unreadNotificationCount > 0 && { beacon: unreadNotificationCount })}

--- a/components/navigation/content/SwapWidgetOrb.tsx
+++ b/components/navigation/content/SwapWidgetOrb.tsx
@@ -19,7 +19,7 @@ export function SwapWidgetOrb() {
       <NavigationOrb
         beacon={!exchangeOnboarded && !exchangeOpened}
         icon="exchange"
-        iconSize={20}
+        iconSize={18}
         onClick={() => {
           setExchangeOpened(true)
           uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {

--- a/components/navigation/content/SwapWidgetOrb.tsx
+++ b/components/navigation/content/SwapWidgetOrb.tsx
@@ -1,13 +1,11 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { NavigationOrb } from 'components/navigation/NavigationMenuOrb'
-import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import {
   SWAP_WIDGET_CHANGE_SUBJECT,
   SwapWidgetChangeAction,
 } from 'features/swapWidget/SwapWidgetChange'
 import { useOnboarding } from 'helpers/useOnboarding'
 import React, { useState } from 'react'
-import { Box } from 'theme-ui'
 
 export function SwapWidgetOrb() {
   const { uiChanges } = useAppContext()
@@ -15,19 +13,16 @@ export function SwapWidgetOrb() {
   const [exchangeOpened, setExchangeOpened] = useState(false)
 
   return (
-    <Box>
-      <NavigationOrb
-        beacon={!exchangeOnboarded && !exchangeOpened}
-        icon="exchange"
-        iconSize={18}
-        onClick={() => {
-          setExchangeOpened(true)
-          uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
-            type: 'open',
-          })
-        }}
-      />
-      <SwapWidgetShowHide />
-    </Box>
+    <NavigationOrb
+      beacon={!exchangeOnboarded && !exchangeOpened}
+      icon="exchange"
+      iconSize={18}
+      onClick={() => {
+        setExchangeOpened(true)
+        uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+          type: 'open',
+        })
+      }}
+    />
   )
 }

--- a/features/navigation/controls/AjnaNavigationController.tsx
+++ b/features/navigation/controls/AjnaNavigationController.tsx
@@ -1,6 +1,7 @@
 import { useAppContext } from 'components/AppContextProvider'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation, navigationBreakpoints } from 'components/navigation/Navigation'
+import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
 import {
   SWAP_WIDGET_CHANGE_SUBJECT,
@@ -17,43 +18,46 @@ export function AjnaNavigationController() {
   const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
 
   return (
-    <Navigation
-      pill={{ label: 'Ajna', color: ['#f154db', '#974eea'] }}
-      links={[
-        {
-          label: 'Borrow',
-          link: INTERNAL_LINKS.ajnaBorrow,
-        },
-        {
-          label: 'Multiply',
-          link: INTERNAL_LINKS.ajnaMultiply,
-        },
-        {
-          label: 'Earn',
-          link: INTERNAL_LINKS.ajnaEarn,
-        },
-        ...(!isViewBelowXl
-          ? [
-              {
-                label: 'Swap',
-                onClick: () => {
-                  uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
-                    type: 'open',
-                  })
+    <>
+      <Navigation
+        pill={{ label: 'Ajna', color: ['#f154db', '#974eea'] }}
+        links={[
+          {
+            label: 'Borrow',
+            link: INTERNAL_LINKS.ajnaBorrow,
+          },
+          {
+            label: 'Multiply',
+            link: INTERNAL_LINKS.ajnaMultiply,
+          },
+          {
+            label: 'Earn',
+            link: INTERNAL_LINKS.ajnaEarn,
+          },
+          ...(!isViewBelowXl
+            ? [
+                {
+                  label: 'Swap',
+                  onClick: () => {
+                    uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+                      type: 'open',
+                    })
+                  },
                 },
-              },
-              ...(isConnected
-                ? [
-                    {
-                      label: <MyPositionsLink />,
-                      link: `/owner/${walletAddress}`,
-                    },
-                  ]
-                : []),
-            ]
-          : []),
-      ]}
-      actions={<NavigationActionsController isConnected={isConnected} />}
-    />
+                ...(isConnected
+                  ? [
+                      {
+                        label: <MyPositionsLink />,
+                        link: `/owner/${walletAddress}`,
+                      },
+                    ]
+                  : []),
+              ]
+            : []),
+        ]}
+        actions={<NavigationActionsController isConnected={isConnected} />}
+      />
+      <SwapWidgetShowHide />
+    </>
   )
 }

--- a/features/navigation/controls/AjnaNavigationController.tsx
+++ b/features/navigation/controls/AjnaNavigationController.tsx
@@ -1,12 +1,18 @@
+import { useAppContext } from 'components/AppContextProvider'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation, navigationBreakpoints } from 'components/navigation/Navigation'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
+import {
+  SWAP_WIDGET_CHANGE_SUBJECT,
+  SwapWidgetChangeAction,
+} from 'features/swapWidget/SwapWidgetChange'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 import { useMediaQuery } from 'usehooks-ts'
 
 export function AjnaNavigationController() {
+  const { uiChanges } = useAppContext()
   const { isConnected, walletAddress } = useAccount()
   const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
 
@@ -26,12 +32,24 @@ export function AjnaNavigationController() {
           label: 'Earn',
           link: INTERNAL_LINKS.ajnaEarn,
         },
-        ...(isConnected && !isViewBelowXl
+        ...(!isViewBelowXl
           ? [
               {
-                label: <MyPositionsLink />,
-                link: `/owner/${walletAddress}`,
+                label: 'Swap',
+                onClick: () => {
+                  uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+                    type: 'open',
+                  })
+                },
               },
+              ...(isConnected
+                ? [
+                    {
+                      label: <MyPositionsLink />,
+                      link: `/owner/${walletAddress}`,
+                    },
+                  ]
+                : []),
             ]
           : []),
       ]}

--- a/features/navigation/controls/NavigationActionsController.tsx
+++ b/features/navigation/controls/NavigationActionsController.tsx
@@ -26,8 +26,8 @@ export function NavigationActionsController({ isConnected }: NavigationActionsCo
     <>
       {isConnected ? (
         <>
+          {isViewBelowXl && swapWidgetFeatureToggle && <SwapWidgetOrb />}
           {isViewBelowXl && <MyPositionsOrb />}
-          {swapWidgetFeatureToggle && <SwapWidgetOrb />}
           <NotificationsOrb />
           {useNetworkSwitcher && <NavigationNetworkSwitcherOrb />}
           {isViewBelowM ? <WalletPanelMobile /> : <WalletOrb />}

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -1,44 +1,63 @@
+import { useAppContext } from 'components/AppContextProvider'
 import { MyPositionsLink } from 'components/navigation/content/MyPositionsLink'
 import { Navigation, navigationBreakpoints } from 'components/navigation/Navigation'
+import { SwapWidgetShowHide } from 'components/swapWidget/SwapWidgetShowHide'
 import { NavigationActionsController } from 'features/navigation/controls/NavigationActionsController'
+import {
+  SWAP_WIDGET_CHANGE_SUBJECT,
+  SwapWidgetChangeAction,
+} from 'features/swapWidget/SwapWidgetChange'
 import { INTERNAL_LINKS } from 'helpers/applicationLinks'
 import { useAccount } from 'helpers/useAccount'
 import React from 'react'
 import { useMediaQuery } from 'usehooks-ts'
 
 export function NavigationController() {
+  const { uiChanges } = useAppContext()
   const { isConnected, walletAddress } = useAccount()
   const isViewBelowXl = useMediaQuery(`(max-width: ${navigationBreakpoints[3]})`)
 
   return (
-    <Navigation
-      links={[
-        {
-          label: 'Borrow',
-          link: INTERNAL_LINKS.borrow,
-        },
-        {
-          label: 'Multiply',
-          link: INTERNAL_LINKS.multiply,
-        },
-        {
-          label: 'Earn',
-          link: INTERNAL_LINKS.earn,
-        },
-        {
-          label: 'Discover',
-          link: INTERNAL_LINKS.discover,
-        },
-        ...(isConnected && !isViewBelowXl
-          ? [
-              {
-                label: <MyPositionsLink />,
-                link: `/owner/${walletAddress}`,
-              },
-            ]
-          : []),
-      ]}
-      actions={<NavigationActionsController isConnected={isConnected} />}
-    />
+    <>
+      <Navigation
+        links={[
+          {
+            label: 'Borrow',
+            link: INTERNAL_LINKS.borrow,
+          },
+          {
+            label: 'Multiply',
+            link: INTERNAL_LINKS.multiply,
+          },
+          {
+            label: 'Earn',
+            link: INTERNAL_LINKS.earn,
+          },
+          ...(!isViewBelowXl
+            ? [
+                {
+                  label: 'Swap',
+                  onClick: () => {
+                    console.log('asd')
+                    uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
+                      type: 'open',
+                    })
+                  },
+                },
+                ...(isConnected
+                  ? [
+                      {
+                        label: <MyPositionsLink />,
+                        link: `/owner/${walletAddress}`,
+                      },
+                    ]
+                  : []),
+              ]
+            : []),
+        ]}
+        actions={<NavigationActionsController isConnected={isConnected} />}
+      />
+      <SwapWidgetShowHide />
+    </>
   )
 }

--- a/features/navigation/controls/NavigationController.tsx
+++ b/features/navigation/controls/NavigationController.tsx
@@ -38,7 +38,6 @@ export function NavigationController() {
                 {
                   label: 'Swap',
                   onClick: () => {
-                    console.log('asd')
                     uiChanges.publish<SwapWidgetChangeAction>(SWAP_WIDGET_CHANGE_SUBJECT, {
                       type: 'open',
                     })

--- a/features/userSettings/UserSettingsView.tsx
+++ b/features/userSettings/UserSettingsView.tsx
@@ -265,7 +265,7 @@ function WalletInfo() {
   return (
     <Grid>
       <Flex sx={{ alignItems: 'center' }}>
-        <BlockNativeAvatar small sx={{ mr: 2 }} />
+        <BlockNativeAvatar sx={{ mr: 2 }} />
         <Grid sx={{ gap: 0, width: '100%' }}>
           <Flex sx={{ justifyContent: 'space-between' }}>
             <Text variant="boldParagraph3" sx={{ letterSpacing: '0.02em' }}>


### PR DESCRIPTION
# [Update navigation](https://app.shortcut.com/oazo-apps/story/9858/summer-fi-various-fixes)

![image](https://github.com/OasisDEX/oasis-borrow/assets/16230404/9081af06-e964-4cd3-b8fa-b0695b125609)
  
## Changes 👷‍♀️

- Shrunk navigation orbs to 50px,
- moved Discover link to footer,
- moved Swap from orbs to links navigation (only on large screens).
  
## How to test 🧪

Self explanatory.
