### PR TITLE
Fix Product Finder Maker multiply products url

### DIFF
--- a/features/productHub/helpers/getActionUrl.ts
+++ b/features/productHub/helpers/getActionUrl.ts
@@ -69,9 +69,11 @@ export function getActionUrl({
         secondaryToken,
       })
     case LendingProtocol.Maker:
-      if (label === 'DSR') {
-        return '/earn/dsr/'
-      }
-      return `/vaults/open/${label.split('/').length ? label.split('/')[0] : label}`
+      if (label === 'DSR') return '/earn/dsr/'
+
+      const openUrl = product.includes(ProductHubProductType.Multiply) ? 'open-multiply' : 'open'
+      const ilkInUrl = label.split('/').length ? label.split('/')[0] : label
+
+      return `/vaults/${openUrl}/${ilkInUrl}`
   }
 }


### PR DESCRIPTION
# Fix Product Finder Maker multiply products url
  
The title says it all.